### PR TITLE
Remove archived components

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,9 +16,8 @@
 		"polymer": "1 - 2",
 		"d2l-colors": "^3.1.2",
 		"d2l-icons": "^5.0.3",
+		"d2l-inputs": "^1.0.2",
 		"d2l-offscreen": "^3.0.3",
-		"d2l-textarea": "BrightspaceUI/textarea#^0.6.3",
-		"d2l-text-input": "BrightspaceUI/text-input#^0.6.0",
 		"d2l-button": "BrightspaceUI/button#^4.5.0",
 		"d2l-typography": "^6.1.2"
 	},

--- a/internal/opt-out-dialog.html
+++ b/internal/opt-out-dialog.html
@@ -3,7 +3,7 @@
 <link rel="import" href="../../d2l-offscreen/d2l-offscreen.html">
 <link rel="import" href="../../d2l-icons/d2l-icons.html">
 <link rel="import" href="../../d2l-button/d2l-button.html">
-<link rel="import" href="../../d2l-textarea/d2l-textarea.html">
+<link rel="import" href="../../d2l-inputs/d2l-input-textarea.html">
 <link rel="import" href="./opt-out-reason-selector.html">
 <link rel="import" href="./translate-behaviour.html">
 
@@ -18,7 +18,7 @@
 				z-index: 950;
 				pointer-events: auto;
 			}
-			
+
 			.opt-out-modal-fade {
 				position: absolute;
 				width: 100%;
@@ -27,7 +27,7 @@
 				opacity: 0.7;
 				z-index: 1;
 			}
-			
+
 			.dialog {
 				position: absolute;
 				box-sizing: border-box;
@@ -38,33 +38,32 @@
 				padding: 1rem;
 				transform: translateX( -50% );
 				z-index: 2;
-				
+
 				border-radius: 0.4rem;
 				border: 1px solid var(--d2l-color-mica);
 				background-color: var(--d2l-color-white);
 				box-shadow: 0 2px 12px rgba( 86, 90, 92, 0.25);
 			}
-			
+
 			label {
 				margin-bottom: 0.5rem;
 			}
-			
+
 			#title-label {
 				font-weight: bold;
 				margin-bottom: 0;
 			}
-			
-			d2l-textarea {
+
+			d2l-input-textarea {
 				height: 5rem;
 				margin-bottom: 1rem;
 				resize: none;
-				overflow: auto;
 			}
-			
+
 			d2l-button {
 				margin-right: 1rem;
 			}
-			
+
 			.close-button {
 				box-sizing: border-box;
 				position: absolute;
@@ -72,29 +71,29 @@
 				right: 1rem;
 				height: 1.4rem;
 				width: 1.4rem;
-				
+
 				border: 1px solid transparent;
 				border-radius: 0.3rem;
 			}
-			
+
 			.close-button > d2l-icon {
 				position: absolute;
 				top: 50%;
 				left: 50%;
 				transform: translate( -50%, -50% );
 			}
-			
+
 			.close-button:hover, .close-button:focus {
 				border-color: var(--d2l-color-mica);
 			}
-			
+
 			.close-button[dir="rtl"] {
 				right: unset;
 				left: 1rem;
 			}
-			
+
 		</style>
-		
+
 		<div class="opt-out-modal-fade"></div>
 		<div class="dialog" role="dialog" arial-labelledby="title-label">
 			<label id="title-label">[[translate('Feedback.Title')]]</label>
@@ -109,7 +108,7 @@
 			</div>
 			<div>
 				<label id="feedback-label">[[translate('Feedback.FeedbackLabel')]]</label>
-				<d2l-textarea id="feedback" aria-labelledby="feedback-label"></d2l-textarea>
+				<d2l-input-textarea id="feedback" aria-labelledby="feedback-label"></d2l-input-textarea>
 			</div>
 			<div>
 				<d2l-button disabled="[[!_reason]]" primary on-tap="_confirm">[[translate('Done')]]</d2l-button>
@@ -130,37 +129,37 @@
 			</div>
 		</div>
 	</template>
-	
+
 	<script>
 		Polymer({
 			is: 'opt-out-dialog',
-			
+
 			properties: {
 				_reason: {
 					type: String,
 					value: null
 				}
 			},
-			
+
 			behaviors: [
 				D2L.PolymerBehaviors.OptInFlyout.TranslateBehavior
 			],
-			
+
 			_cancel: function() {
 				this.fire( 'cancel' );
 			},
-			
+
 			_confirm: function() {
 				if( !this._reason ) {
 					return;
 				}
-				
+
 				this.fire( 'confirm', {
 					reason: this._reason,
 					feedback: (this.$.feedback.value || '').trim()
 				});
 			},
-			
+
 		});
 	</script>
 </dom-module>

--- a/internal/opt-out-reason-selector.html
+++ b/internal/opt-out-reason-selector.html
@@ -1,11 +1,11 @@
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../d2l-text-input/d2l-text-input-shared-styles.html">
+<link rel="import" href="../../d2l-inputs/d2l-input-shared-styles.html">
 <link rel="import" href="../d2l-opt-out-reason.html">
 <link rel="import" href="./translate-behaviour.html">
 
 <dom-module id="opt-out-reason-selector">
 	<template strip-whitespace>
-		<style>
+		<style include="d2l-input-styles">
 			select {
 				@apply --d2l-input;
 				position: relative;
@@ -13,11 +13,11 @@
 				width: 80%;
 				margin-bottom: 1.5rem;
 			}
-			
+
 			select:hover, select:focus {
-				@apply --d2l-input-hover;
+				@apply --d2l-input-hover-focus
 			}
-			
+
 			#options {
 				display: none;
 			}
@@ -33,10 +33,10 @@
 	</template>
 	<script>
 		'use strict';
-		
+
 		Polymer({
 			is: 'opt-out-reason-selector',
-			
+
 			properties: {
 				selected: {
 					type: String,
@@ -51,11 +51,11 @@
 					observer: '_reasonsChanged'
 				}
 			},
-			
+
 			behaviors: [
 				D2L.PolymerBehaviors.OptInFlyout.TranslateBehavior
 			],
-			
+
 			attached: function() {
 				// Polymer 1 compatability
 				if( !Polymer.FlattenedNodesObserver ) {
@@ -63,23 +63,23 @@
 					this._onSlotChanged();
 				}
 			},
-			
+
 			detached: function() {
 				// Polymer 1 compatability
 				if( this._observer && !Polymer.FlattenedNodesObserver ) {
 					Polymer.dom( this.$.options ).unobserveNodes( this._observer );
 				}
 			},
-			
+
 			_onSlotChanged: function() {
 				/* Passing <option> elements directly into a <select> tag with a slot doesn't work.
 				 * Instead, pass in <d2l-opt-out-reason> elements, and this component will construct
 				 * the options from the passed in options.
 				 */
-				
+
 				this.$.selector.selectedIndex = 0;
 				var children = [];
-				
+
 				if( Polymer.FlattenedNodesObserver ) {
 					// Polymer 2
 					children = Polymer.FlattenedNodesObserver.getFlattenedNodes( this.$.options )
@@ -87,7 +87,7 @@
 					// Polymer 1
 					children = Polymer.dom( this.$.options ).getEffectiveChildNodes();
 				}
-				
+
 				children = children.filter( function( child ) {
 					return child && child.tagName === 'D2L-OPT-OUT-REASON' && child.key && child.text;
 				}).map( function( child ) {
@@ -96,7 +96,7 @@
 						text: child.text
 					};
 				});
-				
+
 				if( children.length <= 0 ) {
 					// Use default options if no valid options were provided
 					children = [
@@ -105,34 +105,34 @@
 						{ key: 'JustCheckingSomething', text: this.translate( 'Feedback.Reason.JustCheckingSomething' ) }
 					];
 				}
-				
+
 				this._reasons = [];
 				this._reasons = children;
 			},
-			
+
 			_reasonSelected: function( event ) {
 				var selectionIndex = this.$.selector.selectedIndex;
 				if( selectionIndex < 1 ) {
 					this._setSelected( null );
 					return;
 				}
-				
+
 				var selection = this.$.selector.options[selectionIndex];
 				if( !selection || !selection.value ) {
 					this._setSelected( null );
 					return;
 				}
-				
+
 				this._setSelected( selection.value );
 			},
-			
+
 			_reasonsChanged: function( reasons ) {
 				// [Workaround] dom-repeat inside a <select> element doesn't work in IE11
 				var selectElement = this.$.selector;
 				while( selectElement.childNodes.length > 2 ) {
 					selectElement.removeChild( selectElement.childNodes[1] );
 				}
-				
+
 				reasons.forEach( function( reason ) {
 					var option = document.createElement( 'option' );
 					option.value = reason.key;
@@ -140,7 +140,7 @@
 					selectElement.insertBefore( option, selectElement.lastChild );
 				});
 			}
-			
+
 		});
 	</script>
 </dom-module>


### PR DESCRIPTION
Remove `d2l-textarea` and `d2l-text-input`, use `d2l-inputs`' `d2l-input-textarea` and shared styles file instead.  That way we can remove the archived repos from BSI.

You'll see a small change in the size of the select component, to match the min-height of the other input components.  @mpharoah-d2l is this being used in the monolith yet?