### PR TITLE
Style changes

### DIFF
--- a/internal/flyout-impl.html
+++ b/internal/flyout-impl.html
@@ -11,131 +11,132 @@
 	<template strip-whitespace>
 		<style>
 			:host {
-				position: absolute;
-				overflow: hidden;
-				width: 100%;
 				height: 100%;
+				overflow: hidden;
 				pointer-events: none;
+				position: absolute;
+				width: 100%;
 				@apply --d2l-body-standard-text;
 			}
-			
-			
+
 			#flyout {
+				background-color: white;
+				border-bottom: 1px solid var(--d2l-color-mica);
+				box-sizing: border-box;
+				overflow: visible;
+				padding-bottom: 2rem;
+				pointer-events: auto;
 				position: absolute;
 				top: 0;
 				width: 100%;
 				z-index: 900;
-				overflow: visible;
-				pointer-events: auto;
-				
-				padding-bottom: 2rem;
-				
-				box-sizing: border-box;
-				background-color: white;
-				border-bottom: 1px solid var(--d2l-color-mica);
-				
-				transition: transform 0.5s ease-out;
 			}
-			
+
+			#flyout.flyout-opened {
+				transition: transform 0.2s ease-out;
+			}
+
+			#flyout.flyout-closed {
+				transition: transform 0.2s ease-in;
+			}
+
 			.flyout-opened {
 				transform: translateY( 0 );
 			}
 			.flyout-closed {
 				transform: translateY( -100% );
 			}
-			
+
 			.flyout-content {
 				text-align: center;
 			}
-			
+
 			.flyout-content h1 {
 				@apply --d2l-heading-1;
-				margin-bottom: 0;
+				margin-bottom: 1.2rem;
 			}
-			
+
 			.flyout-text {
+				margin-bottom: 1.5rem;
 				margin-left: auto;
 				margin-right: auto;
-				margin-bottom: 2rem;
 			}
-			
+
 			#description {
-				margin-top: 0;
 				margin-bottom: 0.5rem;
+				margin-top: 0;
 			}
-			
+
 			.flyout-details {
-				max-width: 800px;
 				margin: auto;
 				margin-bottom: 0;
+				max-width: 800px;
 			}
-			
+
 			.flyout-tutorial {
 				margin: auto;
 				margin-top: 0.5em;
 			}
-			
+
 			.flyout-tutorial a {
 				color: var(--d2l-color-celestine);
 				text-decoration: none;
 			}
-			
+
 			.flyout-tutorial a:hover, .flyout-tutorial a:focus {
 				text-decoration: underline;
 			}
-			
+
 			.flyout-buttons {
 				margin-left: auto;
 				margin-right: auto;
 			}
-			
+
 			.flyout-buttons d2l-button {
 				margin-left: 1rem;
 			}
-			
+
 			.flyout-tab-container {
-				position: absolute;
-				top: 100%;
-				left: 50%;
-				transform: translateX( -50% );
 				height: 1rem;
-				width: 100%;
+				left: 50%;
 				max-width: 1230px;
 				pointer-events: none;
-			}
-			
-			.flyout-tab {
-				pointer-events: auto;
 				position: absolute;
-				top: 0;
-				width: 5rem;
-				height: 1rem;
-				padding: 1px;
-				text-align: center;
-				
-				box-sizing: border-box;
+				top: 100%;
+				transform: translateX( -50% );
+				width: 100%;
+			}
+
+			.flyout-tab {
 				background-color: white;
 				border: 1px solid var(--d2l-color-mica);
-				border-top: none;
 				border-radius: 0 0 8px 8px;
-				
+				border-top: none;
+				box-sizing: border-box;
 				cursor: pointer;
+				height: 1rem;
+				padding: 1px;
+				pointer-events: auto;
+				position: absolute;
+				text-align: center;
+				top: 0;
+				width: 5rem;
 			}
-			
-			.flyout-tab:hover, .flyout-tab:focus {
+
+			.flyout-tab:hover {
 				background-color: var(--d2l-color-regolith);
 			}
-			
+
 			.flyout-tab:active, .flyout-tab:focus {
 				outline: 0;
 			}
-			
+
 			.flyout-tab > d2l-icon {
 				margin: auto;
 				vertical-align: top !important;
 			}
 		</style>
-		
+
 		<template is="dom-if" if="[[_optOutDialogOpen]]" restamp="true">
 			<opt-out-dialog
 				on-cancel="_cancelOptOut"
@@ -161,7 +162,7 @@
 						[[details]]
 					</p>
 					<p class="flyout-tutorial">
-					
+
 						<template is="dom-if" if="[[_getTutorialLink(translate,tutorialLink,helpDocsLink,0)]]">
 							<span>[[_getTutorialTextPart(translate,tutorialLink,helpDocsLink,0)]]</span>
 							<a href="[[_getTutorialLink(translate,tutorialLink,helpDocsLink,0)]]" target="_blank" rel="noopener">
@@ -169,7 +170,7 @@
 							</a>
 							<span>[[_getTutorialTextPart(translate,tutorialLink,helpDocsLink,2)]]</span>
 						</template>
-						
+
 						<template is="dom-if" if="[[_getTutorialLink(translate,tutorialLink,helpDocsLink,1)]]">
 							<a href="[[_getTutorialLink(translate,tutorialLink,helpDocsLink,1)]]" target="_blank" rel="noopener">
 								[[_getTutorialTextPart(translate,tutorialLink,helpDocsLink,3)]]
@@ -199,11 +200,11 @@
 			</div>
 		</div>
 	</template>
-	
+
 	<script>
 		Polymer({
 			is: 'flyout-impl',
-			
+
 			properties: {
 				optOut: {
 					type: Boolean,
@@ -249,66 +250,66 @@
 					value: 'CLOSED'
 				}
 			},
-			
+
 			behaviors: [
 				D2L.PolymerBehaviors.OptInFlyout.TranslateBehavior
 			],
-			
+
 			attached: function() {
 				this._visibleState = this.open ? 'OPENED' : 'CLOSED';
-				
+
 				// Polymer doesn't correctly support this event, so we have to add it manually
 				this._onTransitionComplete = this._onTransitionComplete.bind( this );
 				this.$.flyout.addEventListener( 'transitionend', this._onTransitionComplete );
 			},
-			
+
 			detached: function() {
 				this.$.flyout.removeEventListener( 'transitionend', this._onTransitionComplete );
 			},
-			
+
 			_getPrimaryButtonText: function( translate, optOut ) {
 				return translate( optOut ? 'LeaveOn' : 'TurnOn' );
 			},
-			
+
 			_getSecondaryButtonText: function( translate, optOut ) {
 				return translate( optOut ? 'TurnOff' : 'LeaveOff' );
 			},
-			
+
 			_openChanged: function( open, previousValue ) {
 				if( open && this._visibleState === 'CLOSED' || this._visibleState === 'CLOSING' ) {
 					this._visibleState = 'OPENING';
 				} else if( !open && this._visibleState === 'OPENED' || this._visibleState === 'OPENING' ) {
 					this._visibleState = 'CLOSING';
 				}
-				
+
 				if( previousValue !== undefined ) {
 					this.fire( open ? 'flyout-opened' : 'flyout-closed' );
 				}
 			},
-			
+
 			_onTransitionComplete: function( event ) {
 				if( event.target.id !== 'flyout' || event.propertyName !== 'transform' ) {
 					return null;
 				}
-				
+
 				if( this._visibleState === 'OPENING' ) {
 					this._visibleState = 'OPENED';
 				} else if( this._visibleState === 'CLOSING' ) {
 					this._visibleState = 'CLOSED';
 				}
 			},
-			
+
 			_clickTab: function() {
 				if( this._visibleState === 'OPENED' || this._visibleState === 'CLOSED' ) {
 					this.open = !this.open;
 				}
 			},
-			
+
 			_clickOptIn: function() {
 				this.fire( 'opt-in' );
 				this.open = false;
 			},
-			
+
 			_clickOptOut: function() {
 				if( this.optOut ) {
 					this._optOutDialogOpen = true;
@@ -317,23 +318,23 @@
 					this.open = false;
 				}
 			},
-			
+
 			_cancelOptOut: function( event ) {
 				this._optOutDialogOpen = false;
 				event.stopPropagation();
 			},
-			
+
 			_confirmOptOut: function( event ) {
 				this._optOutDialogOpen = false;
 				this.fire( 'opt-out', event.detail );
 				this.open = false;
 				event.stopPropagation();
 			},
-			
+
 			_getContentStyle: function( visibleState ) {
 				return visibleState === 'CLOSED' ? 'visibility: hidden;' : 'visibility: visible;';
 			},
-			
+
 			_getFlyoutClass: function( visibleState ) {
 				if( visibleState === 'OPENING' || visibleState === 'OPENED' ) {
 					return 'flyout-opened';
@@ -341,10 +342,10 @@
 					return 'flyout-closed';
 				}
 			},
-			
+
 			_getTabStyle: function( position, documentTextDirection ) {
 				var rtl = documentTextDirection === 'rtl';
-				
+
 				if( position === 'left' ) {
 					position = 'calc( 2.5rem + 15px )';
 				} else if( position === 'right' || position === 'default' || !position ) {
@@ -357,25 +358,25 @@
 					position = 'calc( 2.5rem + 15px )';
 					rtl = !rtl;
 				}
-				
+
 				var side = rtl ? 'right' : 'left';
 				var shift = rtl ? '50%' : '-50%';
-				
+
 				return side + ': ' + position + '; transform: translateX( ' + shift + ' );';
 			},
-			
+
 			_getTabIcon: function( visibleState ) {
-				if( visibleState === 'CLOSED' || visibleState === 'OPENING' ) {
+				if( visibleState === 'CLOSED' || visibleState === 'CLOSING') {
 					return 'd2l-tier1:chevron-down';
 				} else {
 					return 'd2l-tier1:chevron-up'
 				}
 			},
-			
+
 			_getDescriptionPart: function( translate, i ) {
 				return translate( this.optOut ? 'TurnOffMessage' : 'TurnOnMessage' ).split('*')[i];
 			},
-			
+
 			_getTutorialTextPart: function( translate, tutorialLink, helpDocsLink, i ) {
 				if( tutorialLink && helpDocsLink ) {
 					var translation = translate( 'TutorialAndHelpMessage' );
@@ -387,7 +388,7 @@
 					return null;
 				}
 			},
-			
+
 			_getTutorialLink: function( translate, tutorialLink, helpDocsLink, i ) {
 				if( tutorialLink && helpDocsLink ) {
 					var translation = translate( 'TutorialAndHelpMessage' );
@@ -396,7 +397,7 @@
 				}
 				return tutorialLink || helpDocsLink || null;
 			}
-			
+
 		});
 	</script>
 </dom-module>

--- a/internal/flyout-impl.html
+++ b/internal/flyout-impl.html
@@ -93,7 +93,8 @@
 			}
 
 			.flyout-buttons d2l-button {
-				margin-left: 1rem;
+				margin-left: 0.5rem;
+				margin-right: 0.5rem;
 			}
 
 			.flyout-tab-container {
@@ -123,7 +124,7 @@
 				width: 5rem;
 			}
 
-			.flyout-tab:hover {
+			.flyout-tab:hover, .flyout-tab:focus {
 				background-color: var(--d2l-color-regolith);
 			}
 
@@ -195,7 +196,7 @@
 					aria-labelledby="tab-label"
 					on-tap="_clickTab"
 				>
-					<d2l-icon icon="[[_getTabIcon(_visibleState)]]"></span>
+					<d2l-icon icon="[[_getTabIcon(_visibleState)]]"></d2l-icon>
 				</div>
 			</div>
 		</div>

--- a/internal/opt-out-dialog.html
+++ b/internal/opt-out-dialog.html
@@ -100,14 +100,11 @@
 				<d2l-button disabled="[[!_reason]]" primary on-tap="_confirm">[[translate('Done')]]</d2l-button>
 				<d2l-button on-tap="_cancel">[[translate('Cancel')]]</d2l-button>
 			</div>
-			<d2l-offscreen>
-				<label id="close-label">[[translate('Close')]]</label>
-			</d2l-offscreen>
 			<d2l-button-icon
 				icon="d2l-tier1:close-small"
 				class="close-button"
 				on-tap="_cancel"
-				aria-labelledby="close-label"
+				text="[[translate('Close')]]"
 				dir$="[[documentTextDirection]]"
 			></d2l-button-icon>
 		</div>

--- a/internal/opt-out-dialog.html
+++ b/internal/opt-out-dialog.html
@@ -1,4 +1,6 @@
 <link rel="import" href="../../polymer/polymer.html">
+
+<link rel="import" href="../../d2l-button/d2l-button-icon.html">
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
 <link rel="import" href="../../d2l-offscreen/d2l-offscreen.html">
 <link rel="import" href="../../d2l-icons/d2l-icons.html">
@@ -66,30 +68,14 @@
 			}
 
 			.close-button {
-				border: 1px solid transparent;
-				border-radius: 0.3rem;
-				box-sizing: border-box;
-				height: 1.4rem;
 				position: absolute;
-				top: 1rem;
-				right: 1rem;
-				width: 1.4rem;
-			}
-
-			.close-button > d2l-icon {
-				left: 50%;
-				position: absolute;
-				top: 50%;
-				transform: translate( -50%, -50% );
-			}
-
-			.close-button:hover, .close-button:focus {
-				border-color: var(--d2l-color-mica);
+				top: 0.6rem;
+				right: 0.6rem;
 			}
 
 			.close-button[dir="rtl"] {
-				left: 1rem;
-				right: unset;
+				left: 0.6rem;
+				right: auto;
 			}
 
 		</style>
@@ -118,7 +104,15 @@
 			<d2l-offscreen>
 				<label id="close-label">[[translate('Close')]]</label>
 			</d2l-offscreen>
-			<div
+			<d2l-button-icon
+				icon="d2l-tier1:close-small"
+				class="close-button"
+				on-tap="_cancel"
+				aria-labelledby="close-label"
+				dir$="[[documentTextDirection]]"
+			></d2l-button-icon>
+
+			<!-- <div
 				class="close-button"
 				tabindex="0"
 				role="button"
@@ -127,7 +121,7 @@
 				dir$="[[documentTextDirection]]"
 			>
 				<d2l-icon icon="d2l-tier1:close-small"></d2l-icon>
-			</div>
+			</div> -->
 		</div>
 	</template>
 

--- a/internal/opt-out-dialog.html
+++ b/internal/opt-out-dialog.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../../polymer/polymer.html">
-
 <link rel="import" href="../../d2l-button/d2l-button-icon.html">
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
 <link rel="import" href="../../d2l-offscreen/d2l-offscreen.html">

--- a/internal/opt-out-dialog.html
+++ b/internal/opt-out-dialog.html
@@ -111,17 +111,6 @@
 				aria-labelledby="close-label"
 				dir$="[[documentTextDirection]]"
 			></d2l-button-icon>
-
-			<!-- <div
-				class="close-button"
-				tabindex="0"
-				role="button"
-				aria-labelledby="close-label"
-				on-tap="_cancel"
-				dir$="[[documentTextDirection]]"
-			>
-				<d2l-icon icon="d2l-tier1:close-small"></d2l-icon>
-			</div> -->
 		</div>
 	</template>
 

--- a/internal/opt-out-dialog.html
+++ b/internal/opt-out-dialog.html
@@ -11,45 +11,46 @@
 	<template strip-whitespace>
 		<style>
 			:host {
-				position: absolute;
-				width: 100%;
 				height: 100%;
 				overflow: hidden;
-				z-index: 950;
 				pointer-events: auto;
+				position: absolute;
+				width: 100%;
+				z-index: 950;
 			}
 
 			.opt-out-modal-fade {
+				background-color: var(--d2l-color-white);
+				height: 100%;
+				opacity: 0.7;
 				position: absolute;
 				width: 100%;
-				height: 100%;
-				background-color: var(--d2l-color-white);
-				opacity: 0.7;
 				z-index: 1;
 			}
 
 			.dialog {
-				position: absolute;
+				background-color: var(--d2l-color-white);
+				border: 1px solid var(--d2l-color-mica);
+				border-radius: 0.3rem;
+				box-shadow: 0 2px 12px rgba( 86, 90, 92, 0.25);
 				box-sizing: border-box;
-				top: 7.5%;
 				left: 50%;
-				width: 90%;
 				max-width: 680px;
 				padding: 1rem;
+				position: absolute;
+				top: 7.5%;
 				transform: translateX( -50% );
+				width: 90%;
 				z-index: 2;
-
-				border-radius: 0.4rem;
-				border: 1px solid var(--d2l-color-mica);
-				background-color: var(--d2l-color-white);
-				box-shadow: 0 2px 12px rgba( 86, 90, 92, 0.25);
 			}
 
 			label {
+				display: block;
 				margin-bottom: 0.5rem;
 			}
 
 			#title-label {
+				display: inline;
 				font-weight: bold;
 				margin-bottom: 0;
 			}
@@ -65,21 +66,20 @@
 			}
 
 			.close-button {
+				border: 1px solid transparent;
+				border-radius: 0.3rem;
 				box-sizing: border-box;
+				height: 1.4rem;
 				position: absolute;
 				top: 1rem;
 				right: 1rem;
-				height: 1.4rem;
 				width: 1.4rem;
-
-				border: 1px solid transparent;
-				border-radius: 0.3rem;
 			}
 
 			.close-button > d2l-icon {
+				left: 50%;
 				position: absolute;
 				top: 50%;
-				left: 50%;
 				transform: translate( -50%, -50% );
 			}
 
@@ -88,8 +88,8 @@
 			}
 
 			.close-button[dir="rtl"] {
-				right: unset;
 				left: 1rem;
+				right: unset;
 			}
 
 		</style>
@@ -104,6 +104,7 @@
 					id="reason-selector"
 					aria-labelledby="reason-label"
 					selected="{{_reason}}"
+					dir$="[[documentTextDirection]]"
 				><slot></slot></opt-out-reason-selector>
 			</div>
 			<div>

--- a/internal/opt-out-reason-selector.html
+++ b/internal/opt-out-reason-selector.html
@@ -8,10 +8,26 @@
 		<style include="d2l-input-styles">
 			select {
 				@apply --d2l-input;
-				position: relative;
+				appearance: none;
+				-moz-appearance: none;
+				-webkit-appearance: none;
+				background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2242%22%20height%3D%2242%22%20viewBox%3D%220%200%2042%2042%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23f2f3f5%22%20d%3D%22M0%200h42v42H0z%22%2F%3E%3Cpath%20stroke%3D%22%23d3d9e3%22%20d%3D%22M0%200v42%22%2F%3E%3Cpath%20d%3D%22M14.99%2019.582l4.95%204.95a1.5%201.5%200%200%200%202.122%200l4.95-4.95a1.5%201.5%200%200%200-2.122-2.122L21%2021.35l-3.888-3.89a1.5%201.5%200%200%200-2.12%202.122z%22%20fill%3D%22%23565A5C%22%2F%3E%3C%2Fsvg%3E");
+				background-position: right center;
+				background-repeat: no-repeat;
+				background-size: contain;
 				display: block;
-				width: 80%;
 				margin-bottom: 1.5rem;
+				position: relative;
+				width: 80%;
+			}
+
+			:dir(rtl) select {
+				background-position: left center;
+			}
+
+			/* IE11 and edge */
+			:host([dir="rtl"]) select {
+				background-position: left center;
 			}
 
 			select:hover, select:focus {

--- a/internal/opt-out-reason-selector.html
+++ b/internal/opt-out-reason-selector.html
@@ -21,6 +21,11 @@
 				width: 80%;
 			}
 
+			/* for ie11 - avoid displaying default select arrow */
+			select::-ms-expand {
+				display: none;
+			}
+
 			:dir(rtl) select {
 				background-position: left center;
 			}

--- a/internal/opt-out-reason-selector.html
+++ b/internal/opt-out-reason-selector.html
@@ -26,6 +26,12 @@
 				display: none;
 			}
 
+			/* for ie11 - prevent background box from covering select arrow */
+			select::-ms-value {
+				background-color: transparent;
+				color: var(--d2l-input-color);
+			}
+
 			:dir(rtl) select {
 				background-position: left center;
 			}


### PR DESCRIPTION
Style changes were requested to be made to this component prior to polymer 3 conversion. I'll add some comments throughout to show where these changes are. I also just cleaned up the css a bit in the files I was in.

- ~Hover state of tab should only occur when hovering~
- Adjust padding between title and text, and text and buttons
- Make open/close animation more snappy
- Adjust timing of when the tab chevron flips
- Border radius of feedback dialog should be 6 px instead of 8
- Change select box to be consistent with other daylighty select boxes (note that this should use the web component once that is implemented)
- Use subtle icon button for dialog close button