### PR TITLE
Bump to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/Brightspace/d2l-opt-in-flyout-webcomponent.git"
   },
   "name": "d2l-opt-in-flyout-webcomponent",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "scripts": {
     "start": "polymer serve",
     "test": "npm run test:lint && npm run test:polymer:local",


### PR DESCRIPTION
**2.0.0 -> 2.1.0**

**Flyout**
- Remove default "The new experience is turned on/off" text
- Allow for 2 optional descriptive text elements beneath title. (Will render html tags as html).
- Adjust styling to allow for flyout to be in fixed position
- Fixed focus and hover accessibility issues

**Opt-out Dialog**
- Reason and Feedback are no longer required fields. 'Done' button is enabled even if Reason and/or Feedback are not completed.
- Allow for option to hide Reason and/or Feedback fields from Opt-out dialog