### PR TITLE
Fix build and bump to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/Brightspace/d2l-opt-in-flyout-webcomponent.git"
   },
   "name": "d2l-opt-in-flyout-webcomponent",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "scripts": {
     "start": "polymer serve",
     "test": "npm run test:lint && npm run test:polymer:local",
@@ -45,6 +45,6 @@
     "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",
     "d2l-button": "BrightspaceUI/button#semver:^5",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
-    "s-html": "Brightspace/s-html#semver:^2.0.0"
+    "s-html": "Brightspace/s-html#semver:^2"
   }
 }


### PR DESCRIPTION
Quizzing is having issues building. Think it is because multiple `s-html` copies are being installed.

Quoting DLockhart from slack:
> The special git `semver:^1.0.0` syntax we’re using will result in multiple copies of a dependency for each different pattern. So if there was `semver:^1.0.0` and `semver:^1.0.1` you’d have two copies.

> The solution we’ve been applying today to everything is to reference things without the minor or patch versions: `semver:^1`.