### PR TITLE
focus in dialog on load

### DIFF
--- a/internal/opt-out-dialog.js
+++ b/internal/opt-out-dialog.js
@@ -129,11 +129,11 @@ Polymer({
 
 	attached: function() {
 		if (!this.hideReason) {
-			this.shadowRoot.getElementById('reason-selector').focus();
+			this.$['reason-selector'].focus();
 		} else if (!this.hideFeedback) {
-			this.shadowRoot.getElementById('feedback').focus();
+			this.$['feedback'].focus();
 		} else {
-			this.shadowRoot.getElementById('done-button').focus();
+			this.$['done-button'].focus();
 		}
 	},
 

--- a/internal/opt-out-dialog.js
+++ b/internal/opt-out-dialog.js
@@ -94,7 +94,7 @@ $_documentContainer.innerHTML = `<dom-module id="opt-out-dialog">
 				<d2l-input-textarea id="feedback" aria-labelledby="feedback-label"></d2l-input-textarea>
 			</div>
 			<div>
-				<d2l-button primary="" on-click="_confirm">[[translate('Done')]]</d2l-button>
+				<d2l-button id="done-button" primary="" on-click="_confirm">[[translate('Done')]]</d2l-button>
 				<d2l-button on-click="_cancel">[[translate('Cancel')]]</d2l-button>
 			</div>
 			<d2l-button-icon icon="d2l-tier1:close-small" class="close-button" on-click="_cancel" text="[[translate('Close')]]" dir$="[[documentTextDirection]]"></d2l-button-icon>
@@ -126,6 +126,16 @@ Polymer({
 	behaviors: [
 		D2L.PolymerBehaviors.OptInFlyout.TranslateBehavior
 	],
+
+	attached: function() {
+		if (!this.hideReason) {
+			this.shadowRoot.getElementById('reason-selector').focus();
+		} else if (!this.hideFeedback) {
+			this.shadowRoot.getElementById('feedback').focus();
+		} else {
+			this.shadowRoot.getElementById('done-button').focus();
+		}
+	},
 
 	_cancel: function() {
 		this.fire('cancel');

--- a/internal/opt-out-reason-selector.js
+++ b/internal/opt-out-reason-selector.js
@@ -91,6 +91,10 @@ Polymer({
 		this._onSlotChanged();
 	},
 
+	focus: function() {
+		this.shadowRoot.getElementById('selector').focus();
+	},
+
 	_onSlotChanged: function() {
 		/* Passing <option> elements directly into a <select> tag with a slot doesn't work.
 		 * Instead, pass in <d2l-opt-out-reason> elements, and this component will construct

--- a/internal/opt-out-reason-selector.js
+++ b/internal/opt-out-reason-selector.js
@@ -92,7 +92,7 @@ Polymer({
 	},
 
 	focus: function() {
-		this.shadowRoot.getElementById('selector').focus();
+		this.$.selector.focus();
 	},
 
 	_onSlotChanged: function() {


### PR DESCRIPTION
Currently, when the user clicks "turn it off", and the opt-out-dialog pops up, the focus is still behind, and takes a few "tabs" to get into the dialog. This brings the focus directly into the dialog and to the first element available - either the reason selector, feedback dialog, or done button if neither are present.